### PR TITLE
libyuv public dependecy  ":libyuv_internal(//build/toolchain/win:win_…

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -50,22 +50,7 @@ group("libyuv") {
   all_dependent_configs = [ ":libyuv_config" ]
   deps = []
 
-  if (is_win && target_cpu == "x64") {
-    if (current_os == "winuwp") {
-      public_deps = [
-        ":libyuv_internal",
-      ]
-    } else {
-      # Compile with clang in order to get inline assembly
-      public_deps = [
-        ":libyuv_internal(//build/toolchain/win:win_clang_x64)",
-      ]
-    }
-  } else {
-    public_deps = [
-      ":libyuv_internal",
-    ]
-  }
+  public_deps = [ ":libyuv_internal" ]
 
   if (libyuv_use_neon) {
     deps += [ ":libyuv_neon" ]


### PR DESCRIPTION
…clang_x64)" for win32 x64 is replaced with ":libyuv_internal"